### PR TITLE
Fixed margin not correctly applied

### DIFF
--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -1146,38 +1146,41 @@ namespace Myra.Graphics2D.UI
 			result.X += MBPWidth;
 			result.Y += MBPHeight;
 
+			var marginX = _margin.Left + _margin.Right;
+			var marginY = _margin.Top + _margin.Bottom;
+
 			// Result lerp
 			if (Width.HasValue)
 			{
-				result.X = Width.Value;
+				result.X = Width.Value + marginX;
 			}
 			else
 			{
 				if (MinWidth.HasValue && result.X < MinWidth.Value)
 				{
-					result.X = MinWidth.Value;
+					result.X = MinWidth.Value + marginX;
 				}
 
 				if (MaxWidth.HasValue && result.X > MaxWidth.Value)
 				{
-					result.X = MaxWidth.Value;
+					result.X = MaxWidth.Value + marginX;
 				}
 			}
 
 			if (Height.HasValue)
 			{
-				result.Y = Height.Value;
+				result.Y = Height.Value + marginY;
 			}
 			else
 			{
 				if (MinHeight.HasValue && result.Y < MinHeight.Value)
 				{
-					result.Y = MinHeight.Value;
+					result.Y = MinHeight.Value + marginY;
 				}
 
 				if (MaxHeight.HasValue && result.Y > MaxHeight.Value)
 				{
-					result.Y = MaxHeight.Value;
+					result.Y = MaxHeight.Value + marginY;
 				}
 			}
 


### PR DESCRIPTION
Fixes #385
The `width` / `Height` properties are always without `margin`. Basicaly `content` + `padding` + `border`.
The `result` variable here however needs to calculate the outer bounds of space consumed, which includes `margin`.
This is also stated in the lines directly above, where `MBPWith` and `MBPHeight` is added.
The statements below override the resulting dimensions, but totaly forget to add the `margin`, which this PR fixes.

Code example:
```csharp
public class MainMenuWidget : VerticalStackPanel
{
	public MainMenuWidget(PrototypeGame game)
	{
		this.HorizontalAlignment = HorizontalAlignment.Center;
		this.VerticalAlignment = VerticalAlignment.Center;
		this.Padding = new(9);
		this.Background = new SolidBrush(new Color(0x10, 0x10, 0x10));
		this.Border = new SolidBrush(new Color(0x80, 0x80, 0x80));
		this.BorderThickness = new(1);

		this.AddChild(
			new Label
			{
				Text = "Prototype",
				HorizontalAlignment = HorizontalAlignment.Center,
				Margin = new(0, 0, 0, 10),
				Height = 10
			}
		);

		this.AddChild(new TextButton { Text = "Play", Width = 100, Height = 15, Margin = new(0, 0, 0, 10) });
		this.AddChild(new TextButton { Text = "Exit", Width = 100, Height = 15 });
	}
}

```

Before this PR:
![image](https://user-images.githubusercontent.com/1322277/208057452-7162a4ee-2dcd-42b0-b02d-d757f922d002.png)

With this PR:
![image](https://user-images.githubusercontent.com/1322277/208057334-c0f8ff99-f58e-44be-8327-465ff8c837d7.png)
